### PR TITLE
Add Niri keybind for Obsidian

### DIFF
--- a/home/nixos/niri/keybinds.nix
+++ b/home/nixos/niri/keybinds.nix
@@ -20,6 +20,9 @@
     # "Mod+D".action.spawn = "fuzzel";
     # "Super+Alt+L".action.spawn = "swaylock";
 
+    # Quickly open Obsidian notes
+    "Mod+Ctrl+O".action.spawn = [ "obsidian" ];
+
     # # You can also use a shell. Do this if you need pipes, multiple commands, etc.
     # Note: the entire command goes as a single argument in the end.
     # Mod+T { spawn "bash" "-c" "notify-send hello && exec alacritty"; }


### PR DESCRIPTION
## Summary
- add Mod+Ctrl+O to quickly launch Obsidian

## Testing
- `nix fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686fb0e027b0832c8db8ebbbcd950b3c