### PR TITLE
Add AI context guides

### DIFF
--- a/.cursor/context.mdc
+++ b/.cursor/context.mdc
@@ -1,0 +1,11 @@
+---
+description: General project overview for Cursor AI
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Nix Configuration Overview
+
+This repository hosts a flake-based Nix setup for both macOS and Linux. Home Manager modules are shared across platforms and development shells under `shells/` provide reproducible environments. Use `nix fmt` before committing and `nix flake check` to verify evaluation.
+
+Secrets are stored in `secrets/` using SOPS, and helper functions live in `lib/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,3 +223,8 @@ direnv allow
 - **Missing dependencies**: Check if tools are included in the shell definition
 - **Environment variables**: Verify shellHook configuration
 - **Node.js version conflicts**: Use the version specified in shells configuration (Node.js 24)
+
+## Editor Integrations
+- **ChatGPT Codex**: see `CODEX.md` for CLI guidance.
+- **Cursor**: configuration lives in `.cursor/` with an overview in `CURSOR.md`.
+- **Claude**: this file provides project architecture and usage tips.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,38 @@
+# CODEX.md
+
+This file guides the ChatGPT Codex CLI when working with this repository.
+
+## Overview
+
+This project contains a flake-based Nix configuration supporting both macOS (nix-darwin) and Linux (NixOS). It shares Home Manager modules across platforms and provides reproducible development shells.
+
+### Key Directories
+- `flake.nix` – main flake entry
+- `hosts/` – per-host system configs
+- `modules/` – reusable system modules (`common`, `darwin`, `nixos`)
+- `home/` – Home Manager modules
+- `shells/` – development environments and `.envrc` templates
+- `config-vars.nix` – user preferences
+- `secrets/` – SOPS-encrypted secrets
+
+## Typical Commands
+```bash
+# Build and switch
+sudo darwin-rebuild switch --flake ~/.config/nix#<hostname>
+sudo nixos-rebuild switch --flake ~/.config/nix#<hostname>
+
+# Update inputs and format
+nix flake update
+nix fmt
+
+# Launch development shell
+nix develop ~/.config/nix#shell-selector
+select_dev_shell
+```
+
+## Coding Guidelines
+- Keep cross-platform logic in `common/` directories
+- Use helpers from `lib/functions.nix` for platform detection
+- Run `nix fmt` before committing
+- Validate changes with `nix flake check`
+- Document non-obvious configuration choices

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -1,0 +1,14 @@
+# CURSOR.md
+
+This guide provides Cursor AI with an overview of the repository.
+
+The project defines a cross-platform Nix setup using flakes. Both macOS and Linux machines share Home Manager modules, and development shells in `shells/` offer reproducible tooling for multiple languages.
+
+## Important Locations
+- `hosts/` – per-host system configurations
+- `modules/` – system modules (`common`, `darwin`, `nixos`)
+- `home/` – user-level Home Manager modules
+- `shells/` – dev shells and direnv templates
+- `lib/` – helper functions
+
+Coding conventions and AI behaviour are configured under `.cursor/rules`. Format Nix files with `nix fmt` and consult `README.md` or `CLAUDE.md` for deeper details.


### PR DESCRIPTION
## Summary
- add `CODEX.md` overview for ChatGPT Codex
- add `CURSOR.md` with quick guidance for Cursor AI
- add `.cursor/context.mdc` to provide project context
- document editor integrations in `CLAUDE.md`

## Testing
- `nix flake check` *(fails: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686fb1c23a8c832ca5899f18612390ab