### PR TITLE
Set Firefox as default browser

### DIFF
--- a/home/nixos/desktop-apps.nix
+++ b/home/nixos/desktop-apps.nix
@@ -34,6 +34,9 @@
       "x-terminal-emulator" = "ghostty.desktop";
       "inode/directory" = "org.gnome.Nautilus.desktop";
       "x-scheme-handler/onepassword" = "1password.desktop";
+      "text/html" = "firefox.desktop";
+      "x-scheme-handler/http" = "firefox.desktop";
+      "x-scheme-handler/https" = "firefox.desktop";
       "application/x-ms-dos-executable" = "wine.desktop";
       "application/x-wine-extension-ini" = "wine.desktop";
       "application/x-wine-extension-exe" = "wine.desktop";


### PR DESCRIPTION
## Summary
- associate common web MIME types with Firefox in the Linux desktop apps module

## Testing
- `nix fmt` *(fails: `nix: command not found`)*
- `nix flake check` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686fb4ca79bc832cb7d1109f301bd309