### PR TITLE
Remove extra terminal packages

### DIFF
--- a/home/common/shell.nix
+++ b/home/common/shell.nix
@@ -151,7 +151,6 @@ in
       la = "eza -la";
       lt = "eza --tree";
       ll = "eza -l --git --header";
-      lsd = "eza"; # Fallback alias
       cd = "z";
       find = "fd";
       cat = "bat";

--- a/home/common/shell/sh.nix
+++ b/home/common/shell/sh.nix
@@ -22,17 +22,16 @@
       eval "$(direnv hook zsh)"
       source "${pkgs.fzf}/share/fzf/key-bindings.zsh"
       source "${pkgs.fzf}/share/fzf/completion.zsh"
-      eval "$(mcfly init zsh)"
       export MANPAGER="sh -c 'col -bx | bat -l man -p'"
     '';
 
     shellAliases = {
-      ls = "lsd";
-      l = "ls -l";
-      la = "ls -a";
-      lla = "ls -la";
+      ls = "eza";
+      l = "eza -l";
+      la = "eza -la";
+      lla = "eza -la";
       cd = "z";
-      lt = "ls --tree";
+      lt = "eza --tree";
       edit = "sudo -e";
       update = "system-update";
     };

--- a/home/common/terminal.nix
+++ b/home/common/terminal.nix
@@ -23,23 +23,19 @@ in
       devenv # Development environments
 
       # Enhanced command line tools
-      lsd # Better ls
       eza # Modern ls alternative
       rsync # File synchronization
       trash-cli # Safe rm replacement
       micro # Terminal text editor
       fd # Better find
-      bottom # Better top
       duf # Better df
       ncdu # Disk usage analyzer
       dust # Disk usage tree
-      glances # System monitor
       procs # Better ps
       gping # Ping with graph
       mosh # Mobile shell
       aria2 # Download manager
       tldr # Better man pages
-      mcfly # Shell history
       atuin # Modern shell history
       atool # Archive manager
       pigz # Parallel gzip
@@ -55,7 +51,6 @@ in
       platformLib.platformPackages
         [
           # Linux-specific packages
-          foot # Wayland terminal
           networkmanager # Network management
           doas # Privilege escalation
           lsof # List open files

--- a/home/darwin/apps.nix
+++ b/home/darwin/apps.nix
@@ -1,8 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    tableplus
-    jetbrains.datagrip
     dbeaver-bin
   ];
 }

--- a/home/nixos/browser.nix
+++ b/home/nixos/browser.nix
@@ -69,7 +69,4 @@ in
     };
   };
 
-  home.packages = with pkgs; [
-    google-chrome
-  ];
 }

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -20,7 +20,6 @@
     ./gaming.nix
     ./virtualisation.nix
     ./wine.nix
-    ./terminal.nix
 
     # Development
     ./java.nix

--- a/modules/nixos/terminal.nix
+++ b/modules/nixos/terminal.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  environment.systemPackages = with pkgs; [
-    alacritty
-  ];
-}


### PR DESCRIPTION
## Summary
- trim duplicate terminals and system tools
- drop Chrome, extra DB GUIs
- clean up aliases and history helpers

## Testing
- `nix fmt` *(fails: unable to download from cache.nixos.org)*
- `nix flake check` *(fails: unable to download from cache.nixos.org)*

------
https://chatgpt.com/codex/tasks/task_b_687106c658b8832c83c0dc8816b8be10