### PR TITLE
Fix pnpm fetcher config

### DIFF
--- a/modules/common/core.nix
+++ b/modules/common/core.nix
@@ -44,6 +44,8 @@ in
       allowUnfree = true;
       allowBroken = false;
       allowUnsupportedSystem = false;
+      # Use the latest pnpm fetcher to avoid evaluation errors
+      pnpm.fetcherVersion = 2;
     };
   };
 }


### PR DESCRIPTION
## Summary
- ensure pnpm uses fetcher version 2

## Testing
- `nix fmt` *(fails: unable to download packages)*
- `nix flake check` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_6877a530c5b4832c875aa9c5b821e0f4