### PR TITLE
fix love2d api mcp server command

### DIFF
--- a/home/darwin/mcp.nix
+++ b/home/darwin/mcp.nix
@@ -165,6 +165,7 @@ in
         "mcp"
         "--with"
         "requests"
+        "python"
         "${config.home.homeDirectory}/.config/nix/mcp-servers/love2d-api.py"
       ];
       port = 11440;

--- a/home/nixos/mcp.nix
+++ b/home/nixos/mcp.nix
@@ -157,6 +157,7 @@
         "mcp"
         "--with"
         "requests"
+        "python"
         "${config.home.homeDirectory}/.config/nix/mcp-servers/love2d-api.py"
       ];
       port = 11440;


### PR DESCRIPTION
## Summary
- ensure love2d-api mcp server invokes python explicitly so uvx can run it

## Testing
- `uvx --python python3 --with mcp python - <<'PY' ... PY`


------
https://chatgpt.com/codex/tasks/task_b_6890b7a465a0832cb30a367d444f7dd4