### PR TITLE
Ensure niri keybinds launch Wayland apps via uwsm

### DIFF
--- a/home/nixos/launcher.nix
+++ b/home/nixos/launcher.nix
@@ -9,13 +9,13 @@ in
     settings = {
       main = {
         font = "Iosevka:size=12";
-        terminal = "ghostty -e";
+        terminal = "${pkgs.ghostty}/bin/ghostty -e";
         layer = "overlay";
         width = 30;
         horizontal-pad = 20;
         vertical-pad = 15;
         inner-pad = 5;
-        launch-prefix = "uwsm app --";
+        launch-prefix = "${pkgs.uwsm}/bin/uwsm app --";
         lines = 15;
         line-height = 20;
         letter-spacing = 0;

--- a/home/nixos/niri/keybinds.nix
+++ b/home/nixos/niri/keybinds.nix
@@ -1,14 +1,21 @@
 { config, pkgs, ... }:
 let
   brightness = "${config.home.homeDirectory}/bin/brightness";
+  # Ensure all applications launch through uwsm
+  uwsm = "${pkgs.uwsm}/bin/uwsm";
   # Default applications
   terminal = [
-    "uwsm"
+    uwsm
     "app"
     "--"
     "${pkgs.ghostty}/bin/ghostty"
   ];
-  launcher = "fuzzel";
+  launcher = [
+    uwsm
+    "app"
+    "--"
+    "fuzzel"
+  ];
   screenLocker = "${pkgs.swaylock-effects}/bin/swaylock";
 in
 {
@@ -30,12 +37,12 @@ in
 
     # Suggested binds for running programs: terminal, app launcher, screen locker.
     "Mod+T".action.spawn = terminal;
-    "Mod+D".action.spawn = [ launcher ];
+    "Mod+D".action.spawn = launcher;
     "Super+Alt+L".action.spawn = [ screenLocker ];
 
     # Quickly open Obsidian notes
     "Mod+Ctrl+O".action.spawn = [
-      "uwsm"
+      uwsm
       "app"
       "--"
       "obsidian"
@@ -149,6 +156,7 @@ in
     "Mod+O".action.toggle-overview = { };
 
     "Mod+Q".action.close-window = { };
+    "Mod+Shift+Q".action.kill-window = { };
 
     "Mod+Left".action.focus-column-left = { };
     "Mod+Down".action.focus-window-down = { };

--- a/home/nixos/waybar.nix
+++ b/home/nixos/waybar.nix
@@ -9,6 +9,8 @@ let
     "5" = ""; # Chat
     default = ""; # Unknown
   };
+  uwsm = "${pkgs.uwsm}/bin/uwsm";
+  ghostty = "${pkgs.ghostty}/bin/ghostty";
 in
 {
 
@@ -65,7 +67,7 @@ in
           format-ethernet = " {ifname}";
           tooltip-format = "{ifname} via {gwaddr}\n{ipaddr}/{cidr}\nUp: {bandwidthUpBits}bps\nDown: {bandwidthDownBits}bps";
           interval = 5;
-          on-click = "uwsm app -- nm-connection-editor";
+          on-click = "${uwsm} app -- nm-connection-editor";
         };
 
         # CPU usage (with CSS alert support)
@@ -73,7 +75,7 @@ in
           format = " {usage}%";
           tooltip-format = "CPU: {usage}%\nLoad: {load}";
           interval = 2;
-          on-click = "uwsm app -- ghostty -e btop";
+          on-click = "${uwsm} app -- ${ghostty} -e btop";
           format-alt = "{usage}";
         };
 
@@ -82,7 +84,7 @@ in
           format = " {used:0.1f}G/{total:0.1f}G";
           tooltip-format = "Memory: {used:0.1f}G / {total:0.1f}G\nAvailable: {avail:0.1f}G";
           interval = 5;
-          on-click = "uwsm app -- ghostty -e btop";
+          on-click = "${uwsm} app -- ${ghostty} -e btop";
           format-alt = "{used_percent}";
         };
 
@@ -135,7 +137,7 @@ in
           ];
           tooltip-format = "Device: {desc}\nVolume: {volume}%";
           scroll-step = 5;
-          on-click = "uwsm app -- pavucontrol";
+          on-click = "${uwsm} app -- pavucontrol";
         };
 
         # Clock and calendar
@@ -143,7 +145,7 @@ in
           format = "  {:%a %d %b %H:%M}";
           tooltip-format = "{:%A, %d %B %Y | %H:%M:%S}";
           interval = 60;
-          on-click = "uwsm app -- gsimplecal";
+          on-click = "${uwsm} app -- gsimplecal";
         };
       };
     };


### PR DESCRIPTION
## Summary
- use absolute paths to `uwsm` and `ghostty` in niri keybinds
- update fuzzel launcher and waybar on-click actions to wrap apps with `uwsm`
- add Mod+Shift+Q binding to force kill unresponsive windows

## Testing
- `nix fmt` *(fails: unable to download from cache.nixos.org)*
- `nix flake check --no-build` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_689c5f238ff4832c884803797f4fb19c