### PR TITLE
Restore monitor brightness after KVM switch

### DIFF
--- a/home/nixos/waybar.nix
+++ b/home/nixos/waybar.nix
@@ -151,11 +151,12 @@ in
     };
   };
 
-  # Brightness helper script (unchanged)
+  # Brightness helper script that stores the last set value
   home.file."bin/brightness" = {
     text = ''
       #!/usr/bin/env bash
-      CACHE_FILE="/tmp/brightness_cache"
+      CACHE_FILE="$HOME/.config/niri/last_brightness"
+      mkdir -p "$(dirname "$CACHE_FILE")"
       case "$1" in
         get)
           if [ -f "$CACHE_FILE" ]; then

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -11,6 +11,7 @@
     ./bluetooth.nix
     ./graphics.nix
     ./mouse.nix
+    ./monitor-brightness.nix
     ./usb.nix
 
     # Services

--- a/modules/nixos/monitor-brightness.nix
+++ b/modules/nixos/monitor-brightness.nix
@@ -1,0 +1,17 @@
+{ pkgs, username, ... }:
+let
+  restoreBrightness = pkgs.writeShellScript "restore-external-brightness" ''
+    #!/usr/bin/env bash
+    sleep 2
+    CACHE_FILE="/home/${username}/.config/niri/last_brightness"
+    if [ -f "$CACHE_FILE" ]; then
+      value=$(cat "$CACHE_FILE")
+      ${pkgs.ddcutil}/bin/ddcutil setvcp 10 "$value" --display 1 --brief >/dev/null 2>&1
+    fi
+  '';
+in {
+  environment.systemPackages = with pkgs; [ ddcutil ];
+  services.udev.extraRules = ''
+    SUBSYSTEM=="drm", KERNEL=="card0-DP-1", ACTION=="change", RUN+="${restoreBrightness}"
+  '';
+}


### PR DESCRIPTION
## Summary
- add monitor-brightness module with udev hook to set brightness via ddcutil when displays change
- import monitor-brightness module into NixOS configuration
- persist last brightness in user script for automatic restoration

## Testing
- `nix --extra-experimental-features 'nix-command flakes' fmt --accept-flake-config` *(failed: unable to download 'https://cache.nixos.org/nix-cache-info')*
- `nix --extra-experimental-features 'nix-command flakes' flake check --accept-flake-config` *(failed: unable to download 'https://cache.nixos.org/nix-cache-info')*


------
https://chatgpt.com/codex/tasks/task_b_689c661baef4832cbc4208a4b51a3071