### PR TITLE
Add initial NixOS integration test and CI workflow

### DIFF
--- a/.github/workflows/nixos-tests.yml
+++ b/.github/workflows/nixos-tests.yml
@@ -1,0 +1,17 @@
+name: NixOS Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v22
+
+      - name: Run NixOS Test
+        run: nix build --file tests/default.nix

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,0 +1,29 @@
+{ pkgs ? import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-24.05.tar.gz") {} }:
+
+let
+  home-manager = builtins.getFlake "github:nix-community/home-manager/release-24.05";
+in
+pkgs.testers.runNixOSTest {
+  name = "home-manager-hello";
+
+  nodes.machine = { pkgs, ... }: {
+    imports = [ home-manager.nixosModules.home-manager ];
+
+    users.users.alice = {
+      isNormalUser = true;
+      initialPassword = "password";
+    };
+
+    home-manager.users.alice = {
+      home.packages = [ pkgs.hello ];
+      home.stateVersion = "23.11";
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("default.target")
+    machine.succeed("su - alice -c 'command -v hello'")
+    machine.fail("command -v hello")
+  '';
+}


### PR DESCRIPTION
## Summary
- add first NixOS VM test verifying a Home Manager user package
- run integration test in CI via GitHub Actions

## Testing
- `nix build --file tests/default.nix` *(fails: unable to download dependencies, CONNECT tunnel failed with 403)*

------
https://chatgpt.com/codex/tasks/task_b_689c69881e9c832c879e2cf1d898ceb4